### PR TITLE
Remove mod attribute from .app.src

### DIFF
--- a/src/base58.app.src
+++ b/src/base58.app.src
@@ -7,6 +7,5 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, { ebc, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
The `mod` attribute refers to the `ebc` app, which is backwards, since `ebc` uses `base58` as a support library.
