### PR TITLE
Added necessary information for hex release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{plugins, [rebar3_hex]}.

--- a/src/base58.app.src
+++ b/src/base58.app.src
@@ -7,5 +7,5 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
- ]}.
+  {licenses, ["Apache-2.0"]},
+  {links, [{"GitHub", "https://github.com/aeternity/erl-base58"}]}]}.


### PR DESCRIPTION
The PR makes needed preparations in order to publish the project in `hex`.
Part of Elixir [issue](https://github.com/aeternity/aepp-sdk-elixir/issues/94).
More info [here](https://hex.pm/docs/rebar3_publish).